### PR TITLE
fix typeerror

### DIFF
--- a/train.py
+++ b/train.py
@@ -115,8 +115,8 @@ if(params['num_con_c'] != 0):
     con_c = torch.rand(100, params['num_con_c'], 1, 1, device=device) * 2 - 1
     fixed_noise = torch.cat((fixed_noise, con_c), dim=1)
 
-real_label = 1
-fake_label = 0
+real_label = 1.
+fake_label = 0.
 
 # List variables to store results pf training.
 img_list = []


### PR DESCRIPTION
# Error
```
Traceback (most recent call last):
  File "/workspaces/InfoGAN-PyTorch/train.py", line 149, in <module>
    loss_real = criterionD(probs_real, label)
  File "/home/codespace/.local/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/codespace/.local/lib/python3.10/site-packages/torch/nn/modules/loss.py", line 619, in forward
    return F.binary_cross_entropy(input, target, weight=self.weight, reduction=self.reduction)
  File "/home/codespace/.local/lib/python3.10/site-packages/torch/nn/functional.py", line 3095, in binary_cross_entropy
    return torch._C._nn.binary_cross_entropy(input, target, weight, reduction_enum)
RuntimeError: Found dtype Long but expected Float
```
As you know, Pytorch BCELoss must be a float, not an int. But in train.py, the label is an int, not a float, so the above error occurs. So I edit the code and leave a pull request.

From
```python
real_label = 1
fake_label = 0
```
to
```python
real_label = 1.0
fake_label = 0.0
```

